### PR TITLE
Revert "Merge pull request #9 from tkphd/spelling"

### DIFF
--- a/_episodes/01-intro.md
+++ b/_episodes/01-intro.md
@@ -8,11 +8,11 @@ objectives:
 - "Write and execute our first chapel program."
 keypoints:
 - "Chapel is a compiled language - any programs we make must be compiled with `chpl`."
-- "The `--fast` flag instructs the Chapel compiler to optimize our code."
+- "The `--fast` flag instructs the Chapel compiler to optimise our code."
 - "The `-o` flag tells the compiler what to name our output (otherwise it gets named `a.out`)"
 ---
 
-**_Chapel_** is a modern programming language, developed by _Cray Inc._, that supports HPC via high-level abstractions for data parallelism and task parallelism. These abstractions allow the users to express parallel codes in a natural, almost intuitive, manner. In contrast with other high-level parallel languages, however, Chapel was designed around a _multi-resolution_ philosophy. This means that users can incrementally add more detail to their original code prototype, to optimize it to a particular computer as closely as required. 
+**_Chapel_** is a modern programming language, developed by _Cray Inc._, that supports HPC via high-level abstractions for data parallelism and task parallelism. These abstractions allow the users to express parallel codes in a natural, almost intuitive, manner. In contrast with other high-level parallel languages, however, Chapel was designed around a _multi-resolution_ philosophy. This means that users can incrementally add more detail to their original code prototype, to optimise it to a particular computer as closely as required. 
 
 In a nutshell, with Chapel we can write parallel code with the simplicity and readability of scripting languages such as Python or MATLAB, but achieving performance comparable to compiled languages like C or Fortran (+ traditional parallel libraries such as MPI or OpenMP).
 
@@ -38,7 +38,7 @@ chpl --fast hello.chpl -o hello.o
 ~~~
 {: .bash}
 
-The flag `--fast` indicates the compiler to optimize the binary to run as fast as possible in the given architecture.
+The flag `--fast` indicates the compiler to optimise the binary to run as fast as possible in the given architecture.
 The `-o` option tells Chapel what to call the final output program, in this case `hello.o`.
 
 To run the code, you execute it as you would any other program:
@@ -54,8 +54,8 @@ If we can see this, everything works!
 
 ## Running on a cluster
 
-Depending on the code, it might utilize several or even all cores on the current node. The command above
-implies that you are allowed to utilize all cores. This might not be the case on an HPC cluster, where a
+Depending on the code, it might utilise several or even all cores on the current node. The command above
+implies that you are allowed to utilise all cores. This might not be the case on an HPC cluster, where a
 login node is shared by many people at the same time, and where it might not be a good idea to occupy all
 cores on a login node with CPU-intensive tasks.
 

--- a/_episodes/02-variables.md
+++ b/_episodes/02-variables.md
@@ -5,7 +5,7 @@ exercises: 15
 questions:
 - "How do I write basic Chapel code?"
 objectives:
-- "Perform basic math in Chapel."
+- "Perform basic maths in Chapel."
 - "Understand Chapel's basic data types."
 - "Understand how to read and fix errors."
 - "Know how to define and use data stored as variables."
@@ -15,7 +15,7 @@ keypoints:
 - "Using `const` instead of `var` prevents reassignment."
 ---
 
-Basic math in Chapel works the same as other programming languages. 
+Basic maths in Chapel works the same as other programming languages. 
 Try compiling the following code to see how the different mathematical operators work.
 
 ```
@@ -61,7 +61,7 @@ It can span as many lines as you want!
 
 ## Variables
 
-Granted, we probably want to do more than basic math with Chapel.
+Granted, we probably want to do more than basic maths with Chapel.
 We will need to store the results of complex operations using variables.
 Variables in programming are not the same as the mathematical concept. In programming, a variable is an allocated space in the memory of the computer, where we can store information or data while executing a program. A variable has three elements: 
 
@@ -69,11 +69,11 @@ Variables in programming are not the same as the mathematical concept. In progra
 2. a **_type_**, that indicates the kind of data that we can store in it, and
 3. a **_value_**, the actual information or data stored in the variable.
 
-When we store a value in a variable for the first time, we say that we **_initialized_** it. Further changes to the value of a variable are called **_assignments_**, in general, `x=a` means that we assign the value *a* to the variable *x*.
+When we store a value in a variable for the first time, we say that we **_initialised_** it. Further changes to the value of a variable are called **_assignments_**, in general, `x=a` means that we assign the value *a* to the variable *x*.
 
-Variables in Chapel are declared with the `var` or `const` keywords. When a variable declared as const is initialized, its value cannot be modified anymore during the execution of the program. 
+Variables in Chapel are declared with the `var` or `const` keywords. When a variable declared as const is initialised, its value cannot be modified anymore during the execution of the program. 
 
-In Chapel, to declare a variable we must specify the type of the variable, or initialize it in place with some value. The common variable types in Chapel are:
+In Chapel, to declare a variable we must specify the type of the variable, or initialise it in place with some value. The common variable types in Chapel are:
 
 * integer `int` (positive or negative whole numbers)
 * floating-point number `real` (decimal values)
@@ -101,7 +101,7 @@ The value of test is: 100
 ```
 {: .output}
 
-This constant variable `test` will be created as an integer, and initialized with the value 100. 
+This constant variable `test` will be created as an integer, and initialised with the value 100. 
 No other values can be assigned to these variables during the execution of the program.
 What happens if we try to modify a constant variable like `test`?
 
@@ -159,9 +159,9 @@ It worked! Now we know both how to set, use, and change a variable,
 as well as the implications of using `var` and `const`.
 We also know how to read and interpret errors.
 
-## Uninitialized variables
+## Uninitialised variables
 
-On the other hand, if a variable is declared without an initial value, Chapel will initialize it with a default value depending on the declared type (0.0 for real variables, for example). The following variables will be created as real floating point numbers equal to 0.0.
+On the other hand, if a variable is declared without an initial value, Chapel will initialise it with a default value depending on the declared type (0.0 for real variables, for example). The following variables will be created as real floating point numbers equal to 0.0.
 
 ~~~
 var curdif: real;	//here we will store the greatest difference in temperature from one iteration to another 

--- a/_episodes/03-ranges-arrays.md
+++ b/_episodes/03-ranges-arrays.md
@@ -162,7 +162,7 @@ var temp: [0..rows+1, 0..cols+1] real = 25;
 ~~~
 {:.source}
 
-This is a matrix (2D array) with (`rows + 2`) rows and (`cols + 2`) columns of real numbers, all initialized as 25.0. The ranges `0..rows+1` and `0..cols+1` used here, not only define the size and shape of the array, they stand for the indices with which we could access particular elements of the array using the `[ , ]` notation. For example, `temp[0,0]` is the real variable located at the first row and first column of the array `temp`, while `temp[3,7]` is the one at the 4th row and 8th column; `temp[2,3..15]` access columns 4th to 16th of the 3th row of `temp`, and `temp[0..3,4]` corresponds to the first 4 rows on the 5th column of `temp`.
+This is a matrix (2D array) with (`rows + 2`) rows and (`cols + 2`) columns of real numbers, all initialised as 25.0. The ranges `0..rows+1` and `0..cols+1` used here, not only define the size and shape of the array, they stand for the indices with which we could access particular elements of the array using the `[ , ]` notation. For example, `temp[0,0]` is the real variable located at the first row and first column of the array `temp`, while `temp[3,7]` is the one at the 4th row and 8th column; `temp[2,3..15]` access columns 4th to 16th of the 3th row of `temp`, and `temp[0..3,4]` corresponds to the first 4 rows on the 5th column of `temp`.
 
 We must now be ready to start coding our simulations. Let's print some information about the initial configuration, compile the code, and execute it to see if everything is working as expected.
 

--- a/_episodes/04-conditionals.md
+++ b/_episodes/04-conditionals.md
@@ -97,7 +97,7 @@ while (c < niter && curdif >= mindif) do
 ~~~
 {:.source}
 
-Essentially, what we want is to repeat all the code inside the curly brackets until the number of iterations is greater than or equal to `niter`, or the difference of temperature between iterations is less than `mindif`. (Note that in our case, as `curdif` was not initialized when declared -and thus Chapel assigned it the default real value 0.0-, we need to assign it a value greater than or equal to 0.001, or otherwise the condition of the while statement will never be satisfied. A good starting point is to simple say that `curdif` is equal to `mindif`).
+Essentially, what we want is to repeat all the code inside the curly brackets until the number of iterations is greater than or equal to `niter`, or the difference of temperature between iterations is less than `mindif`. (Note that in our case, as `curdif` was not initialised when declared -and thus Chapel assigned it the default real value 0.0-, we need to assign it a value greater than or equal to 0.001, or otherwise the condition of the while statement will never be satisfied. A good starting point is to simple say that `curdif` is equal to `mindif`).
 
 To count iterations we just need to keep adding 1 to the counter variable `c`. We could do this with `c=c+1`, or with the compound assignment, `+=`, as in the code above. To program the rest of the logic inside the curly brackets, on the other hand, we will need more elaborated instructions. 
 

--- a/_episodes/05-loops.md
+++ b/_episodes/05-loops.md
@@ -7,7 +7,7 @@ questions:
 objectives:
 - "First objective."
 keypoints:
-- "Use `for` statement to org anise a loop."
+- "Use `for` statement to organise a loop."
 ---
 
 To compute the current temperature of an element of `temp`, we need to add all the surrounding elements in `past_temp`, and divide the result by 4. And, essentially, we need to repeat this process for all the elements of `temp`, or, in other words, we need to *iterate* over the elements of `temp`. When it comes to iterate over a given number of elements, the **_for-loop_** is what we want to use. The for-loop has the following general syntax: 
@@ -139,7 +139,7 @@ As we can see, the temperature in the middle of the plate (position 50,50) is sl
 {:.challenge}
 
 > ## Exercise 2
-> Now let's have some more interesting boundary conditions. Suppose that the plate is heated by a source of 80 degrees located at the bottom right corner, and that the temperature on the rest of the border decreases linearly as one gets farther form the corner (see the image below). Utilize for loops to setup the described boundary conditions. Compile and run your code to see how the temperature is changing now. 
+> Now let's have some more interesting boundary conditions. Suppose that the plate is heated by a source of 80 degrees located at the bottom right corner, and that the temperature on the rest of the border decreases linearly as one gets farther form the corner (see the image below). Utilise for loops to setup the described boundary conditions. Compile and run your code to see how the temperature is changing now. 
 >> ## Solution
 >> To get the linear distribution, the 80 degrees must be divided by the number of rows or columns in our plate. So, the following couple of for loops will give us what we want;
 >> ~~~

--- a/_episodes/07-commandargs.md
+++ b/_episodes/07-commandargs.md
@@ -24,7 +24,7 @@ config const niter = 500;    //number of iterations
 ~~~
 {:.input}
 
-it can be initialized with a specific value, when executing the code at the command line, using the syntax:
+it can be initialised with a specific value, when executing the code at the command line, using the syntax:
 
 ~~~
 >> ./base_solution --niter=3000

--- a/_episodes/11-parallel-intro.md
+++ b/_episodes/11-parallel-intro.md
@@ -20,19 +20,19 @@ Suppose that we want to paint the four walls in a room. We'll call this the *pro
 Think of the CPU cores as the painters or workers that will execute your concurrent tasks
 {:.callout}
 
-Now imagine that all workers have to obtain their paint from a central dispenser located at the middle of the room. If each worker is using a different colour, then they can work **_asynchronously_**, however, if they use the same colour, and two of them run out of paint at the same time, then they have to **_synchronize_** to use the dispenser: One must wait while the other is being serviced.  
+Now imagine that all workers have to obtain their paint from a central dispenser located at the middle of the room. If each worker is using a different colour, then they can work **_asynchronously_**, however, if they use the same colour, and two of them run out of paint at the same time, then they have to **_synchronise_** to use the dispenser: One must wait while the other is being serviced.  
 
 > ## Key idea
 Think of the shared memory in your computer as the central dispenser for all your workers
 {:.callout}
 
-Finally, imagine that we have 4 paint dispensers, one for each worker. In this scenario, each worker can complete their task totally on their own. They don't even have to be in the same room, they could be painting walls of different rooms in the house, in different houses in the city, and different cities in the country. We need, however, a communication system in place. Suppose that worker A, for some reason, needs a colour that is only available in the dispenser of worker B, they must then synchronize: worker A must request the paint of worker B and worker B must respond by sending the required colour. 
+Finally, imagine that we have 4 paint dispensers, one for each worker. In this scenario, each worker can complete their task totally on their own. They don't even have to be in the same room, they could be painting walls of different rooms in the house, in different houses in the city, and different cities in the country. We need, however, a communication system in place. Suppose that worker A, for some reason, needs a colour that is only available in the dispenser of worker B, they must then synchronise: worker A must request the paint of worker B and worker B must respond by sending the required colour. 
 
 > ## Key idea
 Think of the memory distributed on each node of a cluster as the different dispensers for your workers
 {:.callout}
 
-A **_fine-grained_** parallel code needs lots of communication or synchronization between tasks, in contrast with a **_coarse-grained_** one. An **_embarrassingly parallel_** problem is one where all tasks can be executed completely independent from each other (no communications required). 
+A **_fine-grained_** parallel code needs lots of communication or synchronisation between tasks, in contrast with a **_coarse-grained_** one. An **_embarrassingly parallel_** problem is one where all tasks can be executed completely independent from each other (no communications required). 
 
 ## Parallel programming in Chapel
 

--- a/_episodes/12-fire-forget-tasks.md
+++ b/_episodes/12-fire-forget-tasks.md
@@ -109,11 +109,11 @@ As you can see the order of the output is not what we would expected, and actual
 >
 > Now submit your job asking for different amount of resources, and use system tools such as `top`or `ps` to monitor the execution of the code.
 >> ## Key idea
->> To maximize performance, start as many tasks as cores are available
+>> To maximise performance, start as many tasks as cores are available
 >{:.solution}
 {:.challenge}
 
-A slightly more structured way to start concurrent tasks in Chapel is by using the `cobegin`statement. Here you can start a block of concurrent tasks, one for each statement inside the curly brackets. The main difference between the `begin`and `cobegin` statements is that with the `cobegin`, all the spawned tasks are synchronized at the end of the statement, i.e. the main thread won't continue its execution until all tasks are done. 
+A slightly more structured way to start concurrent tasks in Chapel is by using the `cobegin`statement. Here you can start a block of concurrent tasks, one for each statement inside the curly brackets. The main difference between the `begin`and `cobegin` statements is that with the `cobegin`, all the spawned tasks are synchronised at the end of the statement, i.e. the main thread won't continue its execution until all tasks are done. 
 
 ~~~
 var x=0;
@@ -154,7 +154,7 @@ The last, and most useful way to start concurrent/parallel tasks in Chapel, is t
 coforall index in iterand 
 {instructions}
 ```
-This will start a new task, for each iteration. Each tasks will then perform all the instructions inside the curly brackets. Each task will have a copy of the variable **_index_** with the corresponding value yielded by the iterand. This index allows us to _customize_ the set of instructions for each particular task. 
+This will start a new task, for each iteration. Each tasks will then perform all the instructions inside the curly brackets. Each task will have a copy of the variable **_index_** with the corresponding value yielded by the iterand. This index allows us to _customise_ the set of instructions for each particular task. 
 
 ~~~
 var x=1;
@@ -189,7 +189,7 @@ this message won't appear until all tasks are done...
  ~~~
  {:.output}
  
-Notice how we are able to customize the instructions inside the coforall, to give different results depending on the task that is executing them. Also, notice how, once again, the variables declared outside the coforall can be read by all tasks, while the variables declared inside, are available only to the particular task. 
+Notice how we are able to customise the instructions inside the coforall, to give different results depending on the task that is executing them. Also, notice how, once again, the variables declared outside the coforall can be read by all tasks, while the variables declared inside, are available only to the particular task. 
 
 > ## Exercise 1
 > Would it be possible to print all the messages in the right order? Modify the code in the last example as required.
@@ -320,9 +320,9 @@ this message won't appear until all tasks are done...
 > Time the execution of the original code and this new one. How do they compare?
 >
 >> ## Key idea
->> It is always a good idea to check whether there is _built-in_ functions or methods in the used language, that can do what we want to do as efficiently (or better) than our house-made code. In this case, the _reduce_ statement reduces the given array to a single number using the given operation (in this case max), and it is parallelized and optimized to have a very good performance. 
+>> It is always a good idea to check whether there is _built-in_ functions or methods in the used language, that can do what we want to do as efficiently (or better) than our house-made code. In this case, the _reduce_ statement reduces the given array to a single number using the given operation (in this case max), and it is parallelized and optimised to have a very good performance. 
 >{:.solution}
 {:.challenge}
 
 
-The code in these last Exercises somehow _synchronize_ the tasks to obtain the desired result. In addition, Chapel has specific mechanisms task synchronization, that could help us to achieve fine-grained parallelization. 
+The code in these last Exercises somehow _synchronise_ the tasks to obtain the desired result. In addition, Chapel has specific mechanisms task synchronisation, that could help us to achieve fine-grained parallelization. 

--- a/_episodes/13-synchronization.md
+++ b/_episodes/13-synchronization.md
@@ -1,5 +1,5 @@
 ---
-title: "Synchronizing tasks"
+title: "Synchronising tasks"
 teaching: 60
 exercises: 30
 questions:
@@ -7,11 +7,11 @@ questions:
 objectives:
 - "First objective."
 keypoints:
-- "You can explicitly synchronize tasks with `sync` statement."
-- "You can also use sync and atomic variables to synchronize tasks."
+- "You can explicitly synchronise tasks with `sync` statement."
+- "You can also use sync and atomic variables to synchronise tasks."
 ---
 
-The keyword `sync` provides all sorts of mechanisms to synchronize tasks in Chapel. 
+The keyword `sync` provides all sorts of mechanisms to synchronise tasks in Chapel. 
 
 We can simply use `sync` to force the _parent_ task to stop and wait until its _spawned-child-task_ ends.
 
@@ -195,7 +195,7 @@ x.writeXF(value)	//will assign the value no matter the state of x, and then set 
 x.readXX()		//will return the value of x regardless its state. The state will remain unchanged
 ~~~
 
-Chapel also implements **_atomic_** operations with variables declared as `atomic`, and this provides another option to synchronize tasks. Atomic operations run completely independently of any other thread or process. This means that when several tasks try to write an atomic variable, only one will succeed at a given moment, providing implicit synchronization between them. There is a number of methods defined for atomic variables, among them `sub()`, `add()`, `write()`, `read()`, and `waitfor()` are very useful to establish explicit synchronization between tasks, as showed in the next code:
+Chapel also implements **_atomic_** operations with variables declared as `atomic`, and this provides another option to synchronise tasks. Atomic operations run completely independently of any other thread or process. This means that when several tasks try to write an atomic variable, only one will succeed at a given moment, providing implicit synchronisation between them. There is a number of methods defined for atomic variables, among them `sub()`, `add()`, `write()`, `read()`, and `waitfor()` are very useful to establish explicit synchronisation between tasks, as showed in the next code:
 
 ~~~
 var lock: atomic int;
@@ -234,7 +234,7 @@ task 4 is done...
 {:.output}
 
 > ## Try this...
-> Comment out the line `lock.waitfor(numtasks)` in the code above to clearly observe the effect of the task synchronization.
+> Comment out the line `lock.waitfor(numtasks)` in the code above to clearly observe the effect of the task synchronisation.
 {:.challenge}
 
 Finally, with all the material studied so far, we should be ready to parallelize our code for the simulation of the heat transfer equation.

--- a/_episodes/14-parallel-case-study.md
+++ b/_episodes/14-parallel-case-study.md
@@ -118,7 +118,7 @@ The greatest difference in temperatures between the last two iterations was: 0.0
 ~~~
 {:.output}
 
-This parallel solution, using 4 parallel tasks, took around 17 seconds to finish. Compared with the ~20 seconds needed by the benchmark solution, seems not very impressive. To understand the reason, let's analyze the code's flow. When the program starts, the main thread does all the declarations and initialisations, and then, it enters the main loop of the simulation (the **_while loop_**). Inside this loop, the parallel tasks are launched for the first time. When these tasks finish their computations, the main task resumes its execution, it updates `curdif`, and everything is repeated again. So, in essence, parallel tasks are launched and resumed 7750 times, which introduces a significant amount of overhead (the time the system needs to effectively start and destroy threads in the specific hardware, at each iteration of the while loop). 
+This parallel solution, using 4 parallel tasks, took around 17 seconds to finish. Compared with the ~20 seconds needed by the benchmark solution, seems not very impressive. To understand the reason, let's analyse the code's flow. When the program starts, the main thread does all the declarations and initialisations, and then, it enters the main loop of the simulation (the **_while loop_**). Inside this loop, the parallel tasks are launched for the first time. When these tasks finish their computations, the main task resumes its execution, it updates `curdif`, and everything is repeated again. So, in essence, parallel tasks are launched and resumed 7750 times, which introduces a significant amount of overhead (the time the system needs to effectively start and destroy threads in the specific hardware, at each iteration of the while loop). 
 
 Clearly, a better approach would be to launch the parallel tasks just once, and have them executing all the simulations, before resuming the main task to print the final results. 
 
@@ -176,13 +176,13 @@ coforall taskid in 0..coltasks*rowtasks-1 do {
 ~~~
 {:.source}
     
-The problem with this approach is that now we have to explicitly synchronize the tasks. Before, `curdif` and `past_temp` were updated only by the main task at each iteration; similarly, only the main task was printing results. Now, all these operations must be carried inside the coforall loop, which imposes the need of synchronization between tasks. 
+The problem with this approach is that now we have to explicitly synchronise the tasks. Before, `curdif` and `past_temp` were updated only by the main task at each iteration; similarly, only the main task was printing results. Now, all these operations must be carried inside the coforall loop, which imposes the need of synchronisation between tasks. 
 
-The synchronization must happen at two points: 
+The synchronisation must happen at two points: 
 1. We need to be sure that all tasks have finished with the computations of their part of the grid `temp`, before updating `curdif` and `past_temp` safely.
 2. We need to be sure that all tasks use the updated value of `curdif` to evaluate the condition of the while loop for the next iteration.
 
-To update `curdif` we could have each task computing the greatest difference in temperature in its associated sub-grid, and then, after the synchronization, have only one task reducing all the sub-grids' maximums.
+To update `curdif` we could have each task computing the greatest difference in temperature in its associated sub-grid, and then, after the synchronisation, have only one task reducing all the sub-grids' maximums.
 
 ~~~
 var curdif: atomic real;
@@ -207,7 +207,7 @@ coforall taskid in 0..coltasks*rowtasks-1 do
     }
     myd[taskid] = myd2
     
-    // here comes the synchronization of tasks
+    // here comes the synchronisation of tasks
     
     past_temp[rowi..rowf,coli..colf] = temp[rowi..rowf,coli..colf];
     if taskid==0 then {
@@ -215,14 +215,14 @@ coforall taskid in 0..coltasks*rowtasks-1 do
       if c%n==0 then writeln('Temperature at iteration ',c,': ',temp[x,y]);
     }
     
-    // here comes the synchronization of tasks again
+    // here comes the synchronisation of tasks again
   }
 }     
 ~~~
 {:.source}
 
 > ## Exercise 4
-> Use `sync` or `atomic` variables to implement the synchronization required in the code above.
+> Use `sync` or `atomic` variables to implement the synchronisation required in the code above.
 >> ## Solution
 >> One possible solution is to use an atomic variable as a _lock_ that opens (using the `waitFor` method) when all the tasks complete the required instructions
 >> ~~~
@@ -239,14 +239,14 @@ coforall taskid in 0..coltasks*rowtasks-1 do
 >>       ...
 >>       myd[taskid]=myd2    
 >>
->>       //here comes the synchronization of tasks
+>>       //here comes the synchronisation of tasks
 >>       lock.add(1);
 >>       lock.waitFor(coltasks*rowtasks);
 >>       
 >>       past_temp[rowi..rowf,coli..colf]=temp[rowi..rowf,coli..colf];
 >>       ...
 >>
->>       //here comes the synchronization of tasks again
+>>       //here comes the synchronisation of tasks again
 >>       lock.sub(1);
 >>       lock.waitFor(0);
 >>    }

--- a/_episodes/22-domains.md
+++ b/_episodes/22-domains.md
@@ -240,7 +240,7 @@ writeln("actual number of threads = ", counter);
 {:.source}
 
 If `n=8` in our code is sufficiently large, there are enough array elements per node (8*8/4 = 16 in our
-case) to fully utilize all three available cores on each node, so our output should be
+case) to fully utilise all three available cores on each node, so our output should be
 
 ~~~
 actual number of threads = 12
@@ -336,7 +336,7 @@ writeln(T);
 ~~~
 {:.source}
 
-Here we initialized an initial Gaussian temperature peak in the middle of the mesh. As we evolve our
+Here we initialised an initial Gaussian temperature peak in the middle of the mesh. As we evolve our
 solution in time, this peak should diffuse slowly over the rest of the domain.
 
 > ## Question
@@ -533,6 +533,6 @@ Run the code and check the file *output.dat*: it should contain the array T afte
 
 * binary I/O
 * write/read NetCDF from Chapel by calling a C/C++ function
-* take a simple non-linear problem, line arise it, implement a parallel multi-locale linear solver
+* take a simple non-linear problem, linearise it, implement a parallel multi-locale linear solver
   entirely in Chapel
 


### PR DESCRIPTION
This reverts commit 344fe7baa5fb9ecd4e95817b807ea079a63b59ce, reversing
changes made to 085efad0f11cff8e1bb48c43657ec806278f05c1.

en_GB is preferred for Carpentries episodes, according to
https://github.com/carpentries/lesson-example/issues/231.
Reverting this merge restores the previously corrected British spellings.

(Sorry for the back-and-forth on this.)