### PR TITLE
assign Chapel team as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,6 @@
 # Each line is a file pattern followed by one or more owners.
 # The sequence matters: later patterns take precedence.
 
-*       alex.razoumov@westgrid.ca
+# FILES  OWNERS
+*        alex.razoumov@westgrid.ca
+*        @hpc-carpentry/hpc-chapel-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,4 @@
 # The sequence matters: later patterns take precedence.
 
 # FILES  OWNERS
-*        alex.razoumov@westgrid.ca
-*        @hpc-carpentry/hpc-chapel-maintainers
+*        alex.razoumov@westgrid.ca @hpc-carpentry/hpc-chapel-maintainers


### PR DESCRIPTION
This will auto-request reviewers, and also provides implicit contact info for inquiries.