### PR TITLE
fix CODEOWNER error

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 # The sequence matters: later patterns take precedence.
 
 # FILES  OWNERS
-*        alex.razoumov@westgrid.ca @hpc-carpentry/hpc-chapel-maintainers
+*        @hpc-carpentry/hpc-chapel-maintainers


### PR DESCRIPTION
The CODEOWNERS file should have one pattern per line. Listing for @razoumov is redundant, so the file is now simplified and moved out of the `.github` folder for better visibility.

By the by, `gh-pages` is a protected branch, and should not be merged into without an approved pull request.