### PR TITLE
Update code to work with Chapel 2.0, quiet some linter warnings

### DIFF
--- a/episodes/01-intro.md
+++ b/episodes/01-intro.md
@@ -35,7 +35,7 @@ Chapel source code must be written in text files with the extension **_.chpl_**.
 world"-type program to demonstrate how we write Chapel code! Using your favourite text editor, create the file
 `hello.chpl` with the following content:
 
-```bash
+```chpl
 writeln('If we can see this, everything works!');
 ```
 
@@ -46,12 +46,14 @@ chpl --fast hello.chpl
 ```
 
 The flag `--fast` indicates the compiler to optimise the binary to run as fast as possible in the given
-architecture. The `-o` option tells Chapel what to call the final output program, in this case `hello.o`.
+architecture. By default, the compiler will produce a program with the same name
+as the source file. In our case, the program will be called `hello`. The `-o`
+option can be used to change the name of the generated binary.
 
 To run the code, you execute it as you would any other program:
 
 ```bash
-./hello.o
+./hello
 ```
 ```output
 If we can see this, everything works!
@@ -82,7 +84,7 @@ and then inside that job compile and run the test code
 
 ```bash
 chpl --fast hello.chpl
-./hello.o
+./hello
 ```
 
 For production jobs, you would compile the code and then submit a batch script to the queue:
@@ -137,5 +139,5 @@ So, our objective is to:
 ::::::::::::::::::::::::::::::::::::: keypoints
 - "Chapel is a compiled language - any programs we make must be compiled with `chpl`."
 - "The `--fast` flag instructs the Chapel compiler to optimise our code."
-- "The `-o` flag tells the compiler what to name our output (otherwise it gets named `a.out`)"
+- "The `-o` flag tells the compiler what to name our output (otherwise it gets named after the source file)"
 ::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/02-variables.md
+++ b/episodes/02-variables.md
@@ -31,7 +31,7 @@ In this example, our code is called `operators.chpl`. You can compile it with th
 
 ```bash
 chpl operators.chpl --fast
-./operators.o
+./operators
 ```
 
 You should see output that looks something like the following:
@@ -139,7 +139,7 @@ writeln("counter is ", counter, " and delta is ", delta);
 ```
 ```bash
 chpl variables.chpl
-./variables.o
+./variables
 ```
 ```output
 counter is 0 and delta is 0.0
@@ -154,7 +154,7 @@ writeln('The value of test is ', test, ' and its type is ', test.type:string);
 ```
 ```bash
 chpl variables.chpl
-./variables.o
+./variables
 ```
 ```output
 The value of test is 100 and its type is int(64)

--- a/episodes/03-ranges-arrays.md
+++ b/episodes/03-ranges-arrays.md
@@ -27,7 +27,7 @@ for x in example_range do writeln(x);
 
 ```bash
 chpl ranges.chpl
-./ranges.o
+./ranges
 ```
 
 ```output
@@ -66,7 +66,7 @@ writeln('When set to a range: ', example_array);
 
 ```bash
 chpl ranges.chpl
-./ranges.o
+./ranges
 ```
 
 ```output
@@ -104,7 +104,7 @@ writeln(example_array);
 
 ```bash
 chpl ranges.chpl
-./ranges.o
+./ranges
 ```
 
 ```output
@@ -139,7 +139,7 @@ writeln(example_array);
 
 ```bash
 chpl ranges.chpl
-./ranges.o
+./ranges
 ```
 
 ```output

--- a/episodes/04-conditionals.md
+++ b/episodes/04-conditionals.md
@@ -28,7 +28,7 @@ writeln(1 <= 2);
 
 ```bash
 chpl conditionals.chpl
-./conditionals.o
+./conditionals
 ```
 
 ```output
@@ -57,7 +57,7 @@ writeln(true || false);
 
 ```bash
 chpl conditionals.chpl
-./conditionals.o
+./conditionals
 ```
 
 ```output
@@ -77,12 +77,19 @@ true
 The general syntax of a while statement is: 
 
 ```chpl
-while condition do 
-{instructions}
+// single-statement form
+while condition do
+  instruction
+
+// multi-statement form
+while condition
+{
+  instructions
+}
 ```
 
 The code flows as follows: first, the condition is evaluated, and then, if it is satisfied, all the
-instructions within the curly brackets are executed one by one. This will be repeated over and over again
+instructions within the curly brackets or `do` are executed one by one. This will be repeated over and over again
 until the condition does not hold anymore.
 
 The main loop in our simulation can be programmed using a while statement like this
@@ -91,7 +98,7 @@ The main loop in our simulation can be programmed using a while statement like t
 //this is the main loop of the simulation
 var c = 0;
 delta = tolerance;
-while (c < niter && delta >= tolerance) do
+while (c < niter && delta >= tolerance)
 {
   c += 1;
   // actual simulation calculations will go here
@@ -115,9 +122,16 @@ at the desired position. This is the type of control that an **_if statement_** 
 is:
 
 ```chpl
-if condition then 
-{instructions A} 
-else 
+// single-statement form
+if condition then
+  instruction A
+else
+  instruction B
+
+// multi-statement form
+if condition
+{instructions A}
+else
 {instructions B}
 ```
 
@@ -158,7 +172,7 @@ writeln('Temperature at start is: ', temp[x, y]);
 //this is the main loop of the simulation
 var c = 0;
 delta = tolerance;
-while (c < niter && delta >= tolerance) do
+while (c < niter && delta >= tolerance)
 {
   c += 1;
   if (c % outputFrequency == 0)
@@ -170,7 +184,7 @@ while (c < niter && delta >= tolerance) do
 
 ```bash
 chpl base_solution.chpl
-./base_solution.o
+./base_solution
 ```
 
 ```output
@@ -207,11 +221,11 @@ Of course the temperature is always 25.0 at any iteration other than the initial
 computation yet.
 
 ::::::::::::::::::::::::::::::::::::: keypoints
-- "Use `if <condition> then {instructions A} else {instructions B}` syntax to execute one set of instructions
+- "Use `if <condition> {instructions A} else {instructions B}` syntax to execute one set of instructions
   if the condition is satisfied, and the other set of instructions if the condition is not satisfied."
-- This syntax can be simplified to `if <condition> then {instructions}` if we only want to execute the
+- This syntax can be simplified to `if <condition> {instructions}` if we only want to execute the
   instructions within the curly brackets if the condition is satisfied.
-- "Use `while <condition> do {instructions}` to repeatedly execute the instructions within the curly brackets
+- "Use `while <condition> {instructions}` to repeatedly execute the instructions within the curly brackets
   while the condition is satisfied. The instructions will be executed over and over again until the condition
   does not hold anymore."
 ::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/04-conditionals.md
+++ b/episodes/04-conditionals.md
@@ -162,6 +162,8 @@ const y = 50;                   // column number of the desired position
 const tolerance = 0.0001;       // smallest difference in temperature that
                                 // would be accepted before stopping
 const outputFrequency: int = 20;   // the temperature will be printed every outputFrequency iterations
+var delta: real;                // greatest difference in temperature from one iteration to another 
+var tmp: real;                  // for temporary results
 
 // this is our "plate"
 var temp: [0..rows+1, 0..cols+1] real = 25;

--- a/episodes/05-loops.md
+++ b/episodes/05-loops.md
@@ -83,6 +83,17 @@ Note that at the end of the outer `for` loop, when all the elements in `temp_new
 `temp` with the values of `temp_new`; this way everything is set up for the next iteration of the main `while`
 statement.
 
+We're ready to execute our code, but the conditions we have initially set up
+will not produce interesting output, because the plate has a temporarture
+value of `25` everywhere. We can change the boundaries to have temperature `0`
+so that the middle will start cooling down. To do this, we should change the
+declaration of `temp` to:
+
+```chpl
+var temp: [0..rows+1, 0..cols+1] real = 0; // the whole plate starts at 0
+temp[1..rows,1..cols] = 25;                // set the non-boundary coordinates to 25
+```
+
 Now let's compile and execute our code again:
 
 ```bash

--- a/episodes/05-loops.md
+++ b/episodes/05-loops.md
@@ -84,7 +84,7 @@ Note that at the end of the outer `for` loop, when all the elements in `temp_new
 statement.
 
 We're ready to execute our code, but the conditions we have initially set up
-will not produce interesting output, because the plate has a temporarture
+will not produce interesting output, because the plate has a temperature
 value of `25` everywhere. We can change the boundaries to have temperature `0`
 so that the middle will start cooling down. To do this, we should change the
 declaration of `temp` to:

--- a/episodes/05-loops.md
+++ b/episodes/05-loops.md
@@ -20,9 +20,14 @@ a given number of elements, the **_for-loop_** is what we want to use. The for-l
 syntax:
 
 ```chpl
+// single-statement version
 for index in iterand do
+  instruction;
+
+// multi-statement version
+for index in iterand
 {instructions}
-``` 
+```
 
 The *iterand* is a function or statement that expresses an iteration; it could be the range 1..15, for
 example. *index* is a variable that exists only in the context of the for-loop, and that will be taking the
@@ -35,7 +40,7 @@ This `for` loop, for example
 
 ```chpl
 // calculate the new temperatures (temp_new) using the past temperatures (temp)
-for i in 1..rows do
+for i in 1..rows
 {
   // do this for every row 
 }
@@ -47,10 +52,10 @@ this:
 
 ```chpl
 // calculate the new temperatures (temp_new) using the past temperatures (temp)
-for i in 1..rows do
+for i in 1..rows
 {
   // do this for every row 
-  for j in 1..cols do
+  for j in 1..cols
   {
     // and this for every column in the row i
   }
@@ -62,10 +67,10 @@ follows:
 
 ```chpl
 // calculate the new temperatures (temp_new) using the past temperatures (temp)
-for i in 1..rows do
+for i in 1..rows
 {
   // do this for every row 
-  for j in 1..cols do
+  for j in 1..cols
   {
     // and this for every column in the row i
     temp_new[i,j] = (temp[i-1,j] + temp[i+1,j] + temp[i,j-1] + temp[i,j+1]) / 4;
@@ -239,9 +244,9 @@ the job:
 ```chpl
 // update delta, the greatest difference between temp_new and temp
 delta=0;
-for i in 1..rows do
+for i in 1..rows
 {
-  for j in 1..cols do
+  for j in 1..cols
   {
     tmp = abs(temp_new[i,j]-temp[i,j]);
     if tmp > delta then delta = tmp;
@@ -337,8 +342,8 @@ The greatest difference in temperatures between the last two iterations was: 0.0
 
 ::::::::::::::::::::::::::::::::::::: keypoints
 - "You can organize loops with `for` and `while` statements. Use a `for` loop to run over every element of the
-  iterand, e.g. `for i in 1..rows do { ...}` will run over all integers from 1 to `rows`. Use a `while`
+  iterand, e.g. `for i in 1..rows { ...}` will run over all integers from 1 to `rows`. Use a `while`
   statement to repeatedly execute a code block until the condition does not hold anymore, e.g. `while (c <
-  niter && delta >= tolerance) do {...}` will repeatedly execute the commands in curly braces until one of the
+  niter && delta >= tolerance) {...}` will repeatedly execute the commands in curly braces until one of the
   two conditions turns false."
 ::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/06-procedures.md
+++ b/episodes/06-procedures.md
@@ -65,8 +65,8 @@ procedure and is used to organize the calculations inside the procedure:
 
 ```chpl
 proc maxOf(x ...?k) { // take a tuple of one type with k elements
-  var maximum = x[1];
-  for i in 2..k do maximum = if maximum < x[i] then x[i] else maximum;
+  var maximum = x[0];
+  for i in 1..<k do maximum = if maximum < x[i] then x[i] else maximum;
   return maximum;
 }
 ```

--- a/episodes/12-fire-forget-tasks.md
+++ b/episodes/12-fire-forget-tasks.md
@@ -302,7 +302,7 @@ config var numoftasks=2;
 
 writeln("This is the main task: x = ",x);
 
-coforall taskid in 1..numoftasks do
+coforall taskid in 1..numoftasks
 {
   var c=taskid+1;
   writeln("this is task ",taskid,": x + ",taskid," = ",x+taskid,". My value of c is: ",c);
@@ -352,7 +352,7 @@ var messages: [1..numoftasks] string;
 
 writeln("This is the main task: x = ", x);
 
-coforall taskid in 1..numoftasks do {
+coforall taskid in 1..numoftasks {
   var c = taskid + 1;
   messages[taskid] = 'this is task ' + taskid:string +
     ': my value of c is ' + c:string + ' and x is ' + x:string;
@@ -412,7 +412,7 @@ const r = nelem - n*numtasks; // these elements did not fit into the last thread
 
 var d: [1..numtasks] int;  // local maxima for each thread
 
-coforall taskid in 1..numtasks do {
+coforall taskid in 1..numtasks {
   var i, f: int;
   i  = (taskid-1)*n + 1;
   f = (taskid-1)*n + n;
@@ -430,7 +430,7 @@ chpl --fast exercise_coforall_2.chpl
 ```
 
 ```output
-the maximum value in x is: 1.0
+the maximum value in x is: 1
 ```
 
 We use the `coforall` loop to spawn tasks that work concurrently in a fraction of the array. The trick here is to

--- a/episodes/12-fire-forget-tasks.md
+++ b/episodes/12-fire-forget-tasks.md
@@ -430,7 +430,7 @@ chpl --fast exercise_coforall_2.chpl
 ```
 
 ```output
-the maximum value in x is: 1
+the maximum value in x is: 9223372034161572255   # large random integer
 ```
 
 We use the `coforall` loop to spawn tasks that work concurrently in a fraction of the array. The trick here is to

--- a/episodes/13-synchronization.md
+++ b/episodes/13-synchronization.md
@@ -227,7 +227,7 @@ use the following functions:
 ```chpl
 // non-blocking methods
 x.reset()	//will set the state as empty and the value as the default of x's type
-x.isfull()	//will return true is the state of x is full, false if it is empty
+x.isFull  	//will return true is the state of x is full, false if it is empty
 
 //blocking read and write methods
 x.writeEF(value)	//will block until the state of x is empty, 

--- a/episodes/14-parallel-case-study.md
+++ b/episodes/14-parallel-case-study.md
@@ -29,12 +29,12 @@ config const coltasks = 2;
 
 // this is the main loop of the simulation
 delta = tolerance;
-while (c<niter && delta>=tolerance) do {
+while (c<niter && delta>=tolerance) {
   c += 1;
 
-  coforall taskid in 0..coltasks*rowtasks-1 do {
-    for i in rowi..rowf do {
-      for j in coli..colf do {
+  coforall taskid in 0..coltasks*rowtasks-1 {
+    for i in rowi..rowf {
+      for j in coli..colf {
         temp_new[i,j] = (temp[i-1,j] + temp[i+1,j] + temp[i,j-1] + temp[i,j+1]) / 4;
       }
     }
@@ -64,17 +64,17 @@ const rc = cols-nc*coltasks;
 
 // this is the main loop of the simulation
 delta = tolerance;
-while (c<niter && delta>=tolerance) do {
+while (c<niter && delta>=tolerance) {
   c+=1;
 
-  coforall taskid in 0..coltasks*rowtasks-1 do {
+  coforall taskid in 0..coltasks*rowtasks-1 {
     var rowi, coli, rowf, colf: int;
     var taskr, taskc: int;
 
     taskr = taskid/coltasks;
     taskc = taskid%coltasks;
 
-    if taskr<rr then {
+    if taskr<rr {
       rowi=(taskr*nr)+1+taskr;
       rowf=(taskr*nr)+nr+taskr+1;
     }
@@ -83,7 +83,7 @@ while (c<niter && delta>=tolerance) do {
       rowf = (taskr*nr)+nr+rr;
     }
 
-    if taskc<rc then {
+    if taskc<rc {
       coli = (taskc*nc)+1+taskc;
       colf = (taskc*nc)+nc+taskc+1;
     }
@@ -92,8 +92,8 @@ while (c<niter && delta>=tolerance) do {
       colf = (taskc*nc)+nc+rc;
     }
 
-    for i in rowi..rowf do {
-      for j in coli..colf do {
+    for i in rowi..rowf {
+      for j in coli..colf {
       ...
 }
 ```
@@ -152,7 +152,7 @@ const rc = cols-nc*coltasks;
 
 // this is the main loop of the simulation
 delta = tolerance;
-coforall taskid in 0..coltasks*rowtasks-1 do {
+coforall taskid in 0..coltasks*rowtasks-1 {
   var rowi, coli, rowf, colf: int;
   var taskr, taskc: int;
   var c = 0;
@@ -160,7 +160,7 @@ coforall taskid in 0..coltasks*rowtasks-1 do {
   taskr = taskid/coltasks;
   taskc = taskid%coltasks;
 
-  if taskr<rr then {
+  if taskr<rr {
     rowi = (taskr*nr)+1+taskr;
     rowf = (taskr*nr)+nr+taskr+1;
   }
@@ -169,7 +169,7 @@ coforall taskid in 0..coltasks*rowtasks-1 do {
     rowf = (taskr*nr)+nr+rr;
   }
 
-  if taskc<rc then {
+  if taskc<rc {
     coli = (taskc*nc)+1+taskc;
     colf = (taskc*nc)+nc+taskc+1;
   }
@@ -178,11 +178,11 @@ coforall taskid in 0..coltasks*rowtasks-1 do {
     colf = (taskc*nc)+nc+rc;
   }
 
-  while (c<niter && delta>=tolerance) do {
+  while (c<niter && delta>=tolerance) {
     c = c+1;
 
-    for i in rowi..rowf do {
-      for j in coli..colf do {
+    for i in rowi..rowf {
+      for j in coli..colf {
         temp_new[i,j] = (temp[i-1,j] + temp[i+1,j] + temp[i,j-1] + temp[i,j+1]) / 4;
       }
     }
@@ -215,17 +215,17 @@ var myd: [0..coltasks*rowtasks-1] real;
 ...
 //this is the main loop of the simulation
 delta.write(tolerance);
-coforall taskid in 0..coltasks*rowtasks-1 do
+coforall taskid in 0..coltasks*rowtasks-1
 {
   var myd2: real;
   ...
 
-  while (c<niter && delta>=tolerance) do {
+  while (c<niter && delta.read() >= tolerance) {
     c = c+1;
     ...
 
-    for i in rowi..rowf do {
-      for j in coli..colf do {
+    for i in rowi..rowf {
+      for j in coli..colf {
         temp_new[i,j] = (temp[i-1,j] + temp[i+1,j] + temp[i,j-1] + temp[i,j+1]) / 4;
         myd2 = max(abs(temp_new[i,j]-temp[i,j]),myd2);
       }
@@ -235,7 +235,7 @@ coforall taskid in 0..coltasks*rowtasks-1 do
     // here comes the synchronisation of tasks
 
     temp[rowi..rowf,coli..colf] = temp_new[rowi..rowf,coli..colf];
-    if taskid==0 then {
+    if taskid==0 {
       delta.write(max reduce myd);
       if c%outputFrequency==0 then writeln('Temperature at iteration ',c,': ',temp[x,y]);
     }
@@ -262,10 +262,10 @@ lock.write(0);
 ...
 //this is the main loop of the simulation
 delta.write(tolerance);
-coforall taskid in 0..coltasks*rowtasks-1 do
+coforall taskid in 0..coltasks*rowtasks-1
 {
    ...
-   while (c<niter && delta>=tolerance) do
+   while (c<niter && delta>=tolerance)
    {
       ...
       myd[taskid]=myd2
@@ -321,6 +321,8 @@ We finish this section by providing another, elegant version of the 2D heat tran
 stepping) using data parallelism on a single locale:
 
 ```chpl
+use Math; /* for exp() */
+
 const n = 100, stride = 20;
 var temp: [0..n+1, 0..n+1] real;
 var temp_new: [1..n,1..n] real;
@@ -332,7 +334,7 @@ for (i,j) in {1..n,1..n} { // serial iteration
 }
 coforall (i,j) in {1..n,1..n} by (stride,stride) { // 5x5 decomposition into 20x20 blocks => 25 tasks
   for k in i..i+stride-1 { // serial loop inside each block
-    for l in j..j+stride-1 do {
+    for l in j..j+stride-1 {
       temp_new[k,l] = (temp[k-1,l] + temp[k+1,l] + temp[k,l-1] + temp[k,l+1]) / 4;
     }
   }

--- a/episodes/21-locales.md
+++ b/episodes/21-locales.md
@@ -139,7 +139,7 @@ We can print few other attributes of each locale. Here it is actually useful to 
 `for` so that the print statements appear in order:
 
 ```chpl
-use Memory.Diagnostics;
+use MemDiagnostics;
 for loc in Locales do
   on loc {
     writeln("locale #", here.id, "...");


### PR DESCRIPTION
This PR is best reviewed commit-by-commit.

The main goal was to fix the Chapel code in the examples that no longer works under Chapel 2.0. Some notable changes fixed by this PR:

* Tuple indexing used to be 1-based, but is now 0-based, necessitating a change to vararg function demonstration
* The `dmapped` keyword now requires `new`, and the distributions are called `blockDist` and `cyclicDist` instead of `Block` and `Cyclic`
* The `isfull()` method on sync variables is now `isFull` (a property)
* `imode` is now `ioMode`
* Using `exp` requires `use Math`
* direct `atomic real >= real` comparison is no longer supported, so use `.read()`

This PR also fixes a number of small typos and bugs (omitted variables, incorrect names (`T` vs `temp`), etc.

The most significant linter-specific change is that `do` is not necessary in loops with `{`: `do` is for single-statement loops, `{` is for loops with multiple statements.

Also, some of the output seems to expect non-`25` boundary conditions, whereas it sets up with `25` boundary conditions. This PR changes the boundaries to `0` for that portion of the code, so that the output of the program matches the expected output.